### PR TITLE
Removed quotes around search term, this broke advanced search operators

### DIFF
--- a/lib/cognitivebing.rb
+++ b/lib/cognitivebing.rb
@@ -91,7 +91,7 @@ class CognitiveBingNews
 
 
     query_string = '?q='
-    query_portion = URI.encode_www_form_component('\'' + search_term + '\'')
+    query_portion = URI.encode_www_form_component(search_term)
     paramsbuilder = "&Ocp-Apim-Subscription-Key=#{@account_key}"
     @params.each do |k,v|
       paramsbuilder << "&#{k.to_s}=#{v.to_s}"

--- a/lib/cognitivebing.rb
+++ b/lib/cognitivebing.rb
@@ -16,7 +16,7 @@ class CognitiveBing
 
 
     query_string = '?q='
-    query_portion = URI.encode_www_form_component('\'' + search_term + '\'')
+    query_portion = URI.encode_www_form_component(search_term)
     params = "&Ocp-Apim-Subscription-Key=#{@account_key}"
     @params.each do |k,v|
       params << "&#{k.to_s}=#{v.to_s}"


### PR DESCRIPTION
Advanced operators in the search term were being ignored due to wrapping the overall search string in single quotes.